### PR TITLE
fix dappnode checkpoint endpoint to be selectable

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -29,7 +29,7 @@ fields:
     title: Checkpoint for fast sync
     description: >-
       To get Lighthouse up and running in only a few minutes, you can start Lighthouse from a recent finalized checkpoint state rather than syncing from genesis. This is substantially **faster** and consumes **less resources** than syncing from genesis, while still providing all the same features.  Be sure you are using a trusted node for the fast sync. Check [Lighthouse docs](https://lighthouse-book.sigmaprime.io/checkpoint-sync.html).
-      Use the dappnode official endpoint **https://checkpoint-sync.dappnode.io/** or get your checkpoint sync from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-chain.infura.io)
+      Use the DAppNode official endpoint at `https://checkpoint-sync.dappnode.io/` or get your checkpoint sync from [Infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-chain.infura.io)
     required: false
   - id: feeRecipientAddress
     target:


### PR DESCRIPTION
made the link to the DAppNode checkpoint sync to be in code block so it can be easily selectable to copy and paste.