### PR TITLE
Fix manifest links to point to this repo

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -15,10 +15,10 @@
   "categories": ["Blockchain", "ETH2.0"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/sigp/lighthouse.git"
+    "url": "https://github.com/dappnode/DAppNodePackage-lighthouse.git"
   },
   "bugs": {
-    "url": "https://github.com/sigp/lighthouse/issues"
+    "url": "https://github.com/dappnode/DAppNodePackage-lighthouse/issues"
   },
   "links": {
     "ui": "http://ui.web3signer.dappnode?signer_url=http://web3signer.web3signer.dappnode:9000",


### PR DESCRIPTION
fixes #9
Issues/bug report link, and git links point to the upstream lighthouse git repos, not our repos