### PR TITLE
Expanded setup to allow unofficial EL clients

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       P2P_PORT: 9104
       CHECKPOINT_SYNC_URL: ""
       EXTRA_OPTS: ""
+      CONFIG_MODE: basic
   validator:
     image: "validator.lighthouse.dnp.dappnode.eth:0.1.0"
     build:

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -3,10 +3,10 @@ fields:
   - title: Execution Client Config Mode
     id: config_mode
     description: >-
-      If you're using an **unofficial** Execution Client on Dappnode, you might have to enable this option to use that Execution Client in the Engine API settings of Lighthouse.   
+      Advanced and Development Use Only: Please only enable this option if you are confident you know what you are doing, if you have any doubts, please use the basic setting.
 
 
-      Set this to **"advanced"** to pass in an arbitrary Execution Client API or leave on **basic** to choose one below.
+      Set this to **"advanced"** to pass in an arbitrary Execution Client Engine-API or leave on **basic** to choose one below.
     target:
       type: environment
       name: CONFIG_MODE
@@ -58,7 +58,7 @@ fields:
 
       Consensus Clients require access to an Execution Client in order to operate properly.   
 
-      You can usually find the Engine API in the Execution Clients Package Info.
+      You can find the Engine API in the Execution Client's Package Info.
     if: { "config_mode": { "enum": ["advanced"] } }
   - id: GRAFFITI
     target:

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -1,6 +1,6 @@
 version: "2"
 fields:
-  - title: Execution Client Config Mode
+  - id: config_mode
     id: config_mode
     description: >-
       Advanced and Development Use Only: Please only enable this option if you are confident you know what you are doing, if you have any doubts, please use the basic setting.

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -1,14 +1,19 @@
 version: "2"
 fields:
-  - id: GRAFFITI
+  - title: Execution Client Config Mode
+    id: config_mode
+    description: >-
+      If you're using an **unofficial** Execution Client on Dappnode, you might have to enable this option to use that Execution Client in the Engine API settings of Lighthouse.   
+
+
+      Set this to **"advanced"** to pass in an arbitrary Execution Client API or leave on **basic** to choose one below.
     target:
       type: environment
-      name: GRAFFITI
-      service: validator
-    title: Graffiti
-    maxLength: 32
-    description: >-
-      Add a string to your proposed blocks, which will be seen on the block explorer
+      name: CONFIG_MODE
+      service: beacon-chain
+    enum:
+      - "basic"
+      - "advanced"
   - id: HTTP_ENGINE
     required: true
     target:
@@ -17,8 +22,10 @@ fields:
       service: beacon-chain
     title: Execution Client Endpoint
     description: >-
-      The Consensus Clients (Lighthouse, Nimbus, Prysm, and Teku) require access to an Execution Client to receive the execution payload by using the Engine API of the Execution Client.
-      This endpoint MUST be provided for an Execution Client that is run locally. 
+      The Consensus Clients (Lighthouse, Nimbus, Prysm, and Teku) require access to an Execution Client to receive the execution payload by using the Engine API of the Execution Client.   
+
+      This endpoint MUST be provided for an Execution Client that is run locally.   
+
       IT IS NO LONGER POSSIBLE TO USE INFURA OR ANY OTHER SERVICE PROVIDER AS YOUR EXECUTION CLIENT.
 
       - Geth [Install link](http://my.dappnode/#/installer/geth.dnp.dappnode.eth)
@@ -34,7 +41,34 @@ fields:
       - "http://geth.dappnode:8551"
       - "http://nethermind.public.dappnode:8551"
       - "http://erigon.dappnode:8551"
-      
+    if: { "config_mode": { "enum": ["basic"] } }    
+  - id: HTTP_ENGINE
+    required: true
+    target:
+      type: environment
+      name: HTTP_ENGINE
+      service: beacon-chain
+    title: Execution Client Endpoint
+    description: >-
+      The Consensus Clients (Lighthouse, Nimbus, Prysm, and Teku) require access to an Execution Client to receive the execution payload by using the Engine API of the Execution Client.   
+
+      This endpoint MUST be provided for an Execution Client that is run locally.   
+
+      IT IS NO LONGER POSSIBLE TO USE INFURA OR ANY OTHER SERVICE PROVIDER AS YOUR EXECUTION CLIENT.   
+
+      Consensus Clients require access to an Execution Client in order to operate properly.   
+
+      You can usually find the Engine API in the Execution Clients Package Info.
+    if: { "config_mode": { "enum": ["advanced"] } }
+  - id: GRAFFITI
+    target:
+      type: environment
+      name: GRAFFITI
+      service: validator
+    title: Graffiti
+    maxLength: 32
+    description: >-
+      Add a string to your proposed blocks, which will be seen on the block explorer
   - id: checkpointSyncUrl
     target:
       type: environment

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -1,7 +1,7 @@
 version: "2"
 fields:
   - id: config_mode
-    id: config_mode
+    title: Execution Client Selection Configuration Mode
     description: >-
       Advanced and Development Use Only: Please only enable this option if you are confident you know what you are doing, if you have any doubts, please use the basic setting.
 


### PR DESCRIPTION
This allows users to use unofficial EL clients in Lighthouse (for example the public Besu package).

The user has to actively toggle the advanced mode to get a free-text field. Basic is pre-selected.

I've also changed the order of items in the setup-wizard to make it less confusing.