### PR TITLE
Set graffiti to max 32 characters

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -54,7 +54,7 @@ exec -c lighthouse \
     --init-slashing-protection \
     --datadir /root/.lighthouse \
     --beacon-nodes $BEACON_NODE_ADDR \
-    --graffiti="$GRAFFITI" \
+    --graffiti="${GRAFFITI:0:32}" \
     --http \
     --http-address 0.0.0.0 \
     --http-port ${VALIDATOR_PORT} \


### PR DESCRIPTION
Even though we set maximum length of graffiti in setup wizard, that value can be edited through config tab after package is installed. If value is longer than 32 characters, validator will not start and that is a pretty significant issue. This ensures that graffiti message is cropped and that validator starts