### PR TITLE
remove unnecessary ENV variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     environment:
       DEBUG_LEVEL: info
       BEACON_API_PORT: 3500
-      HTTP_ENGINE: ""
       CORSDOMAIN: "http://lighthouse.dappnode"
       P2P_PORT: 9104
       CHECKPOINT_SYNC_URL: ""


### PR DESCRIPTION
after stakersUI publishing this was suppsoed to be removed from the compose file of all CCs but was not, causing issues for some. and confusion.