### PR TITLE
bump sigp/lighthouse to v3.4.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "lighthouse.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v3.3.0",
+  "upstreamVersion": "v3.4.0",
   "architectures": ["linux/amd64"],
   "upstreamRepo": "sigp/lighthouse",
   "shortDescription": "Lighthouse ETH2.0 Beacon chain + validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v3.3.0
+        UPSTREAM_VERSION: v3.4.0
     volumes:
       - "beacon-data:/root/.lighthouse"
     ports:
@@ -26,7 +26,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v3.3.0
+        UPSTREAM_VERSION: v3.4.0
     restart: unless-stopped
     security_opt:
       - "seccomp:unconfined"


### PR DESCRIPTION
Bumps upstream version

- [sigp/lighthouse](https://github.com/sigp/lighthouse) from v3.3.0 to [v3.4.0](https://github.com/sigp/lighthouse/releases/tag/v3.4.0)