### PR TITLE
feat: support arm64 arch, bump package version

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "name": "lighthouse.dnp.dappnode.eth",
   "version": "1.0.8",
-  "upstreamVersion": "v4.2.0",
-  "architectures": ["linux/amd64"],
+  "upstreamVersion": "v4.6.0",
+  "architectures": ["linux/amd64", "linux/arm64"],
   "upstreamRepo": "sigp/lighthouse",
   "shortDescription": "Lighthouse ETH2.0 Beacon chain + validator",
   "description": "Lighthouse is an Ethereum 2.0 client that connects to other Ethereum 2.0 clients to form a resilient and decentralized proof-of-stake blockchain.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v4.2.0
+        UPSTREAM_VERSION: v4.6.0
     volumes:
       - "beacon-data:/root/.lighthouse"
     ports:
@@ -26,7 +26,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v4.2.0
+        UPSTREAM_VERSION: v4.6.0
     restart: unless-stopped
     security_opt:
       - "seccomp:unconfined"


### PR DESCRIPTION
Adds support for arm64, which don't require any changes as the lighthouse docker package supports arm64 already. Also bumps the version to v4.6.0.